### PR TITLE
remove redundant call

### DIFF
--- a/NetSock.cpp
+++ b/NetSock.cpp
@@ -201,7 +201,7 @@ NetSock::Connect(const char* host, unsigned short port)
     memcpy(&ip, hostip->h_addr_list[0], 4);
   }
 
-  return this->Connect(htonl(ip), port);
+  return this->Connect(ip, port);
 }
 
 bool


### PR DESCRIPTION
If I understand it correctly the htonl call at 204 is unnecessary, becouse of the htonl call at 224.